### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,5 +89,5 @@ Please read [CONTRIBUTING.md](https://gist.github.com/PurpleBooth/b24679402957c6
 
 
 ## License
-This project is licensed under the GPL-3.0 License - see the [LICENSE.md](LICENSE.md) file for details
+This project is licensed under the GPL-3.0 License - see the [LICENSE](LICENSE) file for details
 


### PR DESCRIPTION
The README.md file has a correction at the last line. As the 'LICENSE.md' file is just been named as 'LICENSE', therefore when we click on the hyperlink it shows a 404 error.